### PR TITLE
Add try/catch for adding checks and pr comments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18240,15 +18240,26 @@ async function action(payload) {
     reportTitle = `Coverage: ${_actual}% (actual) ${_sign} ${minimumCoverage}% (expected)`;
   }
   if (pullRequestNumber && pullRequestComment) {
-    await addComment(pullRequestNumber, comment, reportName);
+    try {
+      await addComment(pullRequestNumber, comment, reportName);
+    } catch (error) {
+      core.error(`❌ Failed to add pull request comment. (${error})`);
+    }
   }
-  await addCheck(
-    checkName,
-    checkBody,
-    reportTitle,
-    commit,
-    failBelowThreshold ? (belowThreshold ? "failure" : "success") : "neutral"
-  );
+
+  try {
+    await addCheck(
+      checkName,
+      checkBody,
+      reportTitle,
+      commit,
+      failBelowThreshold ? (belowThreshold ? "failure" : "success") : "neutral"
+    );
+  } catch (error) {
+    core.error(
+      `❌ Failed to create checks using the provided token. (${error})`
+    );
+  }
 
   if (failBelowThreshold && belowThreshold) {
     core.setFailed("Minimum coverage requirement was not satisfied");

--- a/src/action.js
+++ b/src/action.js
@@ -86,15 +86,26 @@ async function action(payload) {
     reportTitle = `Coverage: ${_actual}% (actual) ${_sign} ${minimumCoverage}% (expected)`;
   }
   if (pullRequestNumber && pullRequestComment) {
-    await addComment(pullRequestNumber, comment, reportName);
+    try {
+      await addComment(pullRequestNumber, comment, reportName);
+    } catch (error) {
+      core.error(`❌ Failed to add pull request comment. (${error})`);
+    }
   }
-  await addCheck(
-    checkName,
-    checkBody,
-    reportTitle,
-    commit,
-    failBelowThreshold ? (belowThreshold ? "failure" : "success") : "neutral"
-  );
+
+  try {
+    await addCheck(
+      checkName,
+      checkBody,
+      reportTitle,
+      commit,
+      failBelowThreshold ? (belowThreshold ? "failure" : "success") : "neutral"
+    );
+  } catch (error) {
+    core.error(
+      `❌ Failed to create checks using the provided token. (${error})`
+    );
+  }
 
   if (failBelowThreshold && belowThreshold) {
     core.setFailed("Minimum coverage requirement was not satisfied");


### PR DESCRIPTION
This PR adds try/catch blocks for creating github checks and pr comments, this is specifically so that the action does not bomb out when it's running using underprivileged tokens